### PR TITLE
Adding Face Search analysis

### DIFF
--- a/source/consumers/elastic/lambda_handler.py
+++ b/source/consumers/elastic/lambda_handler.py
@@ -247,6 +247,7 @@ def process_face_search(asset, workflow, results):
                         for face in item["FaceMatches"]:
                             item["KnownFaceSimilarity"] = face["Similarity"]
                             item["MatchingKnownFaceId"] = face["Face"]["FaceId"]
+                            item["ExternalImageId"] = face["Face"]["ExternalImageId"]
                             item["KnownFaceBoundingBox"] = face["Face"]["BoundingBox"]
                             item["ImageId"] = face["Face"]["ImageId"]
                         del item["FaceMatches"]


### PR DESCRIPTION
In a "known faces" Rekognition collection a face has an ExternalImageId (that can be either a 3rd party GUID or an actual name of the person, which is useful for demos) and a FaceId (generated internally).
It is useful (to avoid an extra call to Rekognition API) to include this property of a recognised face in the ElasticSearch, to expose it in the webapp

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
